### PR TITLE
Allow to exclude web architectures in development mode

### DIFF
--- a/History.md
+++ b/History.md
@@ -4,6 +4,13 @@
 
 * The `meteor-babel` npm package has been updated to version 7.7.4.
 
+* You can now use the `--exclude-archs` CLI argument for the run command
+  to temporarily disable building certain web architectures.
+  For example: `meteor run --exclude-archs web.browser.legacy`.
+  You can pass multiple architectures comma seperated.
+  This can be used to improve rebuild times if you're not actively testing
+  those architectures during development.
+
 ## v1.8.2, 2019-11-14
 
 ### Breaking changes

--- a/packages/appcache/appcache-server.js
+++ b/packages/appcache/appcache-server.js
@@ -251,10 +251,12 @@ function eachResource({
 }
 
 function sizeCheck() {
-  const sizes = [ // Check size of each known architecture independently.
+  const RESOURCE_SIZE_LIMIT = 5 * 1024 * 1024; // 5MB
+  const largeSizes = [ // Check size of each known architecture independently.
     "web.browser",
     "web.browser.legacy",
-  ].reduce((filt, arch) => {
+  ].filter((arch) => !!WebApp.clientPrograms[arch])
+  .map((arch) => {
     let totalSize = 0;
 
     WebApp.clientPrograms[arch].manifest.forEach(resource => {
@@ -265,22 +267,21 @@ function sizeCheck() {
       }
     });
 
-    if (totalSize > 5 * 1024 * 1024) {
-      filt.push({
-        arch,
-        size: totalSize
-      });
+    return {
+      arch,
+      size: totalSize,
     }
-    return filt;
-  }, []);
-  if (sizes.length > 0) {
+  })
+  .filter(({ size }) => size > RESOURCE_SIZE_LIMIT);
+
+  if (largeSizes.length > 0) {
     Meteor._debug([
       "** You are using the appcache package, but the size of",
       "** one or more of your cached resources is larger than",
       "** the recommended maximum size of 5MB which may break",
       "** your app in some browsers!",
       "** ",
-      ...sizes.map(data => `** ${data.arch}: ${(data.size / 1024 / 1024).toFixed(1)}MB`),
+      ...largeSizes.map(data => `** ${data.arch}: ${(data.size / 1024 / 1024).toFixed(1)}MB`),
       "** ",
       "** See http://docs.meteor.com/#appcache for more",
       "** information and fixes."

--- a/packages/webapp/webapp_server.js
+++ b/packages/webapp/webapp_server.js
@@ -402,6 +402,12 @@ WebAppInternals.staticFilesMiddleware = async function (
     identifyBrowser(req.headers["user-agent"]),
   );
 
+  if (! hasOwn.call(WebApp.clientPrograms, arch)) {
+    // We could come here in case we run with some architectures excluded
+    next();
+    return;
+  }
+
   // If pauseClient(arch) has been called, program.paused will be a
   // Promise that will be resolved when the program is unpaused.
   const program = WebApp.clientPrograms[arch];
@@ -984,6 +990,19 @@ function runWebAppServer() {
         parseRequest(req).pathname,
         request.browser,
       );
+
+      if (! hasOwn.call(WebApp.clientPrograms, arch)) {
+        // We could come here in case we run with some architectures excluded
+        headers['Cache-Control'] = 'no-cache';
+        res.writeHead(404, headers);
+        if (Meteor.isDevelopment) {
+          res.end(`No client program found for the ${arch} architecture.`);
+        } else {
+          // Safety net, but this branch should not be possible.
+          res.end("404 Not Found");
+        }
+        return;
+      }
 
       // If pauseClient(arch) has been called, program.paused will be a
       // Promise that will be resolved when the program is unpaused.

--- a/tools/cli/commands.js
+++ b/tools/cli/commands.js
@@ -318,7 +318,8 @@ var runCommandOptions = {
     // Allow the version solver to make breaking changes to the versions
     // of top-level dependencies.
     'allow-incompatible-update': { type: Boolean },
-    'extra-packages': { type: String }
+    'extra-packages': { type: String },
+    'exclude-archs': { type: String }
   },
   catalogRefresh: new catalog.Refresh.Never()
 };
@@ -340,6 +341,13 @@ function doRunCommand(options) {
   var includePackages = [];
   if (options['extra-packages']) {
     includePackages = options['extra-packages'].trim().split(/\s*,\s*/);
+  }
+
+  var excludeArchs = [];
+  const excludableArchs = ['web.browser', 'web.browser.legacy', 'web.cordova'];
+  if (options['exclude-archs']) {
+    excludeArchs = options['exclude-archs'].trim().split(/\s*,\s*/)
+      .filter(arch => excludableArchs.includes(arch));
   }
 
   var projectContext = new projectContextModule.ProjectContext({
@@ -400,6 +408,8 @@ function doRunCommand(options) {
     }
   }
 
+  webArchs = webArchs.filter(arch => !excludeArchs.includes(arch));
+ 
   let cordovaRunner;
   if (!_.isEmpty(runTargets)) {
 

--- a/tools/cli/help.txt
+++ b/tools/cli/help.txt
@@ -103,6 +103,9 @@ Options:
                    version constraints.
   --extra-packages Run with additional packages (comma separated, for example:
                    --extra-packages "package-name1, package-name2@1.2.3")
+  --exclude-archs  Don't create bundles for certain web architectures
+                  (comma separated, for example:
+                   --exclude-archs "web.browser.legacy, web.cordova")
 
 >>> debug
 Run the project with server-side debugging enabled.


### PR DESCRIPTION
This commit implements an --exclude-archs arg to the run command
which allows you to pass a comma-seperated list of architectures
to exclude.